### PR TITLE
Fix error when SSL debug enabled but no port

### DIFF
--- a/src/wcs/esp8266/ESP8266_WCS.cpp
+++ b/src/wcs/esp8266/ESP8266_WCS.cpp
@@ -55,7 +55,7 @@ extern "C"
 #include <c_types.h>
 #include <coredecls.h>
 
-#ifdef DEBUG_ESP_SSL
+#if defined(DEBUG_ESP_SSL) && defined(DEBUG_ESP_PORT)
 #define DEBUG_BSSL(fmt, ...) DEBUG_ESP_PORT.printf_P((PGM_P)PSTR("BSSL:" fmt), ##__VA_ARGS__)
 #else
 #define DEBUG_BSSL(...)


### PR DESCRIPTION
## Description:
<!-- 
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

When the Debug Level is set to SSL but the Debug Port is set to "Disabled", do not enable debugging calls.

Fixes #111 

## Type of change:
<!-- 
What types of changes does your code introduce to this project ? 

_Put an `x` in the boxes that apply_
-->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Testing:
<!-- 
_Put an `x` in the boxes that apply_
-->

- [X] merged with the current development branch (before testing)
- [ ] CI build finished without issues
- [X] Tested on real hardware (ESP01-S)
- [X] Changes are backward compatible

## Checklist:
<!-- 
_Put an `x` in the boxes that apply_
-->

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

<!-- https://raw.githubusercontent.com/appium/appium/master/.github/PULL_REQUEST_TEMPLATE.md --> 