### PR TITLE
Fix subject header field encoding issue with uppercase encoding scheme names

### DIFF
--- a/src/ESP_Mail_Client.cpp
+++ b/src/ESP_Mail_Client.cpp
@@ -674,7 +674,10 @@ void ESP_Mail_Client::decodeHeader(MB_String &headerField)
   {
     p2 = headerField.find("?", p1 + 2);
     if (p2 != MB_String::npos)
+    {
       headerEnc = headerField.substr(p1 + 2, p2 - p1 - 2);
+      headerEnc.toLowerCase();
+    }
   }
 
   int bufSize = 512;

--- a/src/ESP_Mail_Client.cpp
+++ b/src/ESP_Mail_Client.cpp
@@ -676,7 +676,6 @@ void ESP_Mail_Client::decodeHeader(MB_String &headerField)
     if (p2 != MB_String::npos)
     {
       headerEnc = headerField.substr(p1 + 2, p2 - p1 - 2);
-      headerEnc.toLowerCase();
     }
   }
 
@@ -711,9 +710,9 @@ esp_mail_char_decoding_scheme ESP_Mail_Client::getEncodingFromCharset(const char
 {
   esp_mail_char_decoding_scheme scheme = esp_mail_char_decoding_scheme_default;
 
-  if (strposP(enc, esp_mail_str_237, 0) > -1 || strposP(enc, esp_mail_str_231, 0) > -1 || strposP(enc, esp_mail_str_226, 0) > -1)
+  if (strposP(enc, esp_mail_str_237, 0, false) > -1 || strposP(enc, esp_mail_str_231, 0, false) > -1 || strposP(enc, esp_mail_str_226, 0, false) > -1)
     scheme = esp_mail_char_decoding_scheme_tis620;
-  else if (strposP(enc, esp_mail_str_227, 0) > -1)
+  else if (strposP(enc, esp_mail_str_227, 0, false) > -1)
     scheme = esp_mail_char_decoding_scheme_iso8859_1;
 
   return scheme;

--- a/src/extras/MB_String.h
+++ b/src/extras/MB_String.h
@@ -1132,6 +1132,11 @@ public:
             buf[len] = '\0';
     }
 
+    void toLowerCase()
+    {
+	    strlwr(buf);
+    }
+    
     MB_String &replace(size_t pos, size_t len, const char *replace)
     {
         size_t repLen = strlen(replace);

--- a/src/extras/MB_String.h
+++ b/src/extras/MB_String.h
@@ -1131,11 +1131,6 @@ public:
         if (_reserve(len, true))
             buf[len] = '\0';
     }
-
-    void toLowerCase()
-    {
-	    strlwr(buf);
-    }
     
     MB_String &replace(size_t pos, size_t len, const char *replace)
     {


### PR DESCRIPTION
## Description:
<!-- 
This is a fix for issue #154: Some Android gMail Apps seem to use uppercase letters for the encoding scheme, when encoding the subject header field. This results in invalid decoding of the header, since the encoding scheme is matched against a lowercase label. The fix iconverts the headerEnc to lowercase to avoid this issue. For doing so a new method toLowerCase() is added to the MB_String class.
-->

## Type of change:
<!-- 
What types of changes does your code introduce to this project ? 

_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Testing:
<!-- 
_Put an `x` in the boxes that apply_
-->

- [x] merged with the current development branch (before testing)
- [x] CI build finished without issues
- [x] Tested on real hardware (ESP32 WT32-SC01)
- [x] Changes are backward compatible

## Checklist:
<!-- 
_Put an `x` in the boxes that apply_
-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

<!-- https://raw.githubusercontent.com/appium/appium/master/.github/PULL_REQUEST_TEMPLATE.md --> 