### PR TITLE
Update ESP_Mail_SMTP.h for iCloud Mail Compatibility

### DIFF
--- a/src/ESP_Mail_SMTP.h
+++ b/src/ESP_Mail_SMTP.h
@@ -544,7 +544,7 @@ bool ESP_Mail_Client::sendContent(SMTPSession *smtp, SMTP_Message *msg, bool clo
     if (msg->sender.name.length() > 0)
     {
         appendString(buf2, msg->sender.name.c_str(), false, false, esp_mail_string_mark_type_double_quote);
-        appendString(buf2, " ", false, false, esp_mail_string_mark_type_none);
+        appendSpace(buf2);
     }
 
     appendString(buf2, msg->sender.email.c_str(), false, true, esp_mail_string_mark_type_angle_bracket);
@@ -593,7 +593,7 @@ bool ESP_Mail_Client::sendContent(SMTPSession *smtp, SMTP_Message *msg, bool clo
         if (msg->_rcp[i].name.length() > 0)
         {
             appendString(buf2, msg->_rcp[i].name.c_str(), i > 0, false, esp_mail_string_mark_type_double_quote);
-            appendString(buf2, " ", false, false, esp_mail_string_mark_type_none);
+            appendSpace(buf2);
         }
 
         appendString(buf2, msg->_rcp[i].email.c_str(), i > 0, i == msg->_rcp.size() - 1, esp_mail_string_mark_type_angle_bracket);

--- a/src/ESP_Mail_SMTP.h
+++ b/src/ESP_Mail_SMTP.h
@@ -542,7 +542,10 @@ bool ESP_Mail_Client::sendContent(SMTPSession *smtp, SMTP_Message *msg, bool clo
     appendHeaderName(buf2, rfc822_headers[esp_mail_rfc822_header_field_from].text);
 
     if (msg->sender.name.length() > 0)
+    {
         appendString(buf2, msg->sender.name.c_str(), false, false, esp_mail_string_mark_type_double_quote);
+        appendString(buf2, " ", false, false, esp_mail_string_mark_type_none);
+    }
 
     appendString(buf2, msg->sender.email.c_str(), false, true, esp_mail_string_mark_type_angle_bracket);
 
@@ -588,7 +591,10 @@ bool ESP_Mail_Client::sendContent(SMTPSession *smtp, SMTP_Message *msg, bool clo
             appendHeaderName(buf2, rfc822_headers[esp_mail_rfc822_header_field_to].text);
 
         if (msg->_rcp[i].name.length() > 0)
+        {
             appendString(buf2, msg->_rcp[i].name.c_str(), i > 0, false, esp_mail_string_mark_type_double_quote);
+            appendString(buf2, " ", false, false, esp_mail_string_mark_type_none);
+        }
 
         appendString(buf2, msg->_rcp[i].email.c_str(), i > 0, i == msg->_rcp.size() - 1, esp_mail_string_mark_type_angle_bracket);
 


### PR DESCRIPTION
Although RFC 822 allows, but does not require a space between the sender/recipient name and the sender/recipient address, the Apple iCloud service requires this in order for IMAP SEARCH queries, involving FROM or TO HEADER fields, to work.

## Description:
<!-- 
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Basically the change just adds a space between the sender/recipient name and the sender/recipient address, as allowed by RFC 822.

## Type of change:
<!-- 
What types of changes does your code introduce to this project ? 

_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Testing:
<!-- 
_Put an `x` in the boxes that apply_
-->

- [x] merged with the current development branch (before testing)
- [x] CI build finished without issues
- [x] Tested on real hardware (List board here)
- [x] Changes are backward compatible

## Checklist:
<!-- 
_Put an `x` in the boxes that apply_
-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

<!-- https://raw.githubusercontent.com/appium/appium/master/.github/PULL_REQUEST_TEMPLATE.md --> 