### PR TITLE
Update ESP_Mail_Client.h

### DIFF
--- a/src/ESP_Mail_Client.h
+++ b/src/ESP_Mail_Client.h
@@ -996,6 +996,18 @@ public:
 
   MB_Time Time;
 
+  // Get encoding type from character set string
+  esp_mail_char_decoding_scheme getEncodingFromCharset(const char *enc);
+
+  // Decode Latin1 to UTF-8
+  int decodeLatin1_UTF8(unsigned char *out, int *outlen, const unsigned char *in, int *inlen);  
+
+  // Decode TIS620 to UTF-8
+  void decodeTIS620_UTF8(char *out, const char *in, size_t len);
+
+  // handle rfc2047 Q (quoted printable) and B (base64) decodings
+  RFC2047_Decoder RFC2047Decoder;
+
 private:
   friend class SMTPSession;
   friend class IMAPSession;
@@ -1424,9 +1436,6 @@ private:
 
 #if defined(ENABLE_IMAP)
 
-  // handle rfc2047 Q (quoted printable) and B (base64) decodings
-  RFC2047_Decoder RFC2047Decoder;
-
   // Check if child part (part number string) is a member of the parent part (part number string)
   // part number string format: <part number>.<sub part number>.<sub part number>
   bool multipartMember(const MB_String &parent, const MB_String &child);
@@ -1443,14 +1452,8 @@ private:
   // Actually not decode because 8bit string is enencode string unless prepare valid 8bit string
   char *decode8Bit_UTF8(char *buf);
 
-  // Get encoding type from character set string
-  esp_mail_char_decoding_scheme getEncodingFromCharset(const char *enc);
-
   // Decode string base on encoding
   void decodeString(IMAPSession *imap, MB_String &string, const char *enc = "");
-
-  // Decode Latin1 to UTF-8
-  int decodeLatin1_UTF8(unsigned char *out, int *outlen, const unsigned char *in, int *inlen);
 
   /**
    * Encode a code point using UTF-8
@@ -1465,9 +1468,6 @@ private:
    * @return number of bytes on success, 0 on failure (also produces U+FFFD, which uses 3 bytes)
    */
   int encodeUnicode_UTF8(char *out, uint32_t utf);
-
-  // Decode TIS620 to UTF-8
-  void decodeTIS620_UTF8(char *out, const char *in, size_t len);
 
   // Network reconnection and return the connection status
   bool reconnect(IMAPSession *imap, unsigned long dataTime = 0, bool downloadRequestuest = false);

--- a/src/ESP_Mail_Client.h
+++ b/src/ESP_Mail_Client.h
@@ -1000,7 +1000,7 @@ public:
   esp_mail_char_decoding_scheme getEncodingFromCharset(const char *enc);
 
   // Decode Latin1 to UTF-8
-  int decodeLatin1_UTF8(unsigned char *out, int *outlen, const unsigned char *in, int *inlen);  
+  int decodeLatin1_UTF8(unsigned char *out, int *outlen, const unsigned char *in, int *inlen);
 
   // Decode TIS620 to UTF-8
   void decodeTIS620_UTF8(char *out, const char *in, size_t len);

--- a/src/ESP_Mail_Client.h
+++ b/src/ESP_Mail_Client.h
@@ -996,6 +996,8 @@ public:
 
   MB_Time Time;
 
+#if defined(ENABLE_IMAP)
+
   // Get encoding type from character set string
   esp_mail_char_decoding_scheme getEncodingFromCharset(const char *enc);
 
@@ -1007,6 +1009,8 @@ public:
 
   // handle rfc2047 Q (quoted printable) and B (base64) decodings
   RFC2047_Decoder RFC2047Decoder;
+
+#endif
 
 private:
   friend class SMTPSession;


### PR DESCRIPTION
Make getEncodingFromCharset(), decodeLatin1_UTF8(), decodeTIS620_UTF8() and RFC2047Decoder public.

## Description:

This makes getEncodingFromCharset(), decodeLatin1_UTF8(), decodeTIS620_UTF8() and RFC2047Decoder public ([see discussion #288 ](https://github.com/mobizt/ESP-Mail-Client/discussions/288)).


## Type of change:
<!-- 
What types of changes does your code introduce to this project ? 

_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Testing:
<!-- 
_Put an `x` in the boxes that apply_
-->

- [ ] merged with the current development branch (before testing)
- [ ] CI build finished without issues
- [x] Tested on real hardware (List board here)
- [x] Changes are backward compatible

## Checklist:
<!-- 
_Put an `x` in the boxes that apply_
-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

<!-- https://raw.githubusercontent.com/appium/appium/master/.github/PULL_REQUEST_TEMPLATE.md --> 