### PR TITLE
bugfix: impossible to use TinyGSM without ESP Wifi

### DIFF
--- a/src/ESP_Mail_TCPClient.h
+++ b/src/ESP_Mail_TCPClient.h
@@ -445,7 +445,7 @@ public:
         if (_client_type == esp_mail_client_type_external_generic_client &&
             (!_network_connection_cb || !_network_status_cb))
             rdy = false;
-        else if (_client_type != esp_mail_client_type_external_generic_client ||
+        else if (_client_type != esp_mail_client_type_external_generic_client &&
                  _client_type != esp_mail_client_type_external_gsm_client)
             rdy = false;
 #else


### PR DESCRIPTION
## Description:
Scenario: ESP32 with WIFI and an external SIM7080. Using PlatformIO with these build flags:
```
build_flags = -DESP_MAIL_DISABLE_ONBOARD_WIFI -DESP_MAIL_DISABLE_NATIVE_ETHERNET -DDISABLE_IMAP -DTINY_GSM_MODEM_SIM7080
```
Was unable to succesfully pass the initialization, after debugging, found out an impossible _if condition_:

```c
#if !defined(ESP_MAIL_WIFI_IS_AVAILABLE)
  if (_client_type != 'external_generic_client' || _client_type != 'external_gsm_client')
  {
      rdy = false;
  }
#endif
```
imho i should be able to pass this check, but `rdy` kept being false... 

## Type of change:
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Testing:
- [ ] merged with the current development branch (before testing)
- [ ] CI build finished without issues
- [x] Tested on real hardware (ESP32)
- [ ] Changes are backward compatible

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation